### PR TITLE
Documentation & compiler errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Build was tested on Debian wheezy and OSX 10.10. In OSX, the
 RandomForest library will not build easily since OpenMP is not
 included in clang, but this is an optional feature.
 
+* GCC/G++ 4.9 (might need to include `-std=c++11` or `-std=gnu++11` in the C/C++ compiler flags)
+* libconfig
 * CMAKE 2.8
 * ITK is required, versions tested and working are 4.5-4.8. Turn
   USE_REVIEW and ITKv3Compatibility on.
@@ -63,16 +65,15 @@ installed by the user under their respective license. Note that the
 optimizers are optional and can be enabled/disabled during cmake
 configuration. The respective dependencies and checks will be automatically added to the build.
 
-* OpenGM can be obtained here: http://hci.iwr.uni-heidelberg.de/opengm2/
+* OpenGM can be obtained here: http://hci.iwr.uni-heidelberg.de/opengm2/ (https://github.com/opengm/opengm)
 current wrapper utilizes BOOST, so make sure to install opengm with their boost feature enabled
 Note that openGM comes with a wide variety of discrete optimizers and wrappers, but may be less efficient than using the direct wrappers provided by SRS directly (TRW-S, GCO)
 
 * TRW-S can be downloaded here: http://research.microsoft.com/en-us/downloads/dad6c31e-2c04-471f-b724-ded18bf70fe3/
-A patch will be applied automatically during the build process. This will disable all energyTypes except typeGeneral from the downloaded library because the extended functionality was not implemented for those.
+Copy the source into the folder `source/External/TRWS`. A patch will be applied automatically during the build process. This will disable all energyTypes except typeGeneral from the downloaded library because the extended functionality was not implemented for those.
 
 * GCO can be downloaded here: http://vision.csd.uwo.ca/code/
-The same directory can also be used as root for the binary graph-cut
-(GC) optimizer.
+Copy this code into the folder `source/External/GCO`. The same directory can also be used as root for the binary graph-cut (GC) optimizer, which is expected inside the folder `source/External/maxflow`.
 
 A choice of classifiers is available which can be optionally
 enabled/disabled. C-UGMIX is a Gaussian mixture model estimator, and RF a

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Note that openGM comes with a wide variety of discrete optimizers and wrappers, 
 Copy the source into the folder `source/External/TRWS`. A patch will be applied automatically during the build process. This will disable all energyTypes except typeGeneral from the downloaded library because the extended functionality was not implemented for those.
 
 * GCO can be downloaded here: http://vision.csd.uwo.ca/code/
-Copy this code into the folder `source/External/GCO`. The same directory can also be used as root for the binary graph-cut (GC) optimizer, which is expected inside the folder `source/External/maxflow`.
+Copy this code into the folder `source/External/GCO`. The same directory can also be used as root for the binary graph-cut (GC) optimizer, which is expected inside the folder `source/External/maxFlow`.
 
 A choice of classifiers is available which can be optionally
 enabled/disabled. C-UGMIX is a Gaussian mixture model estimator, and RF a

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 
 if( ${USE_TRWS} MATCHES "ON" )
-  set(DIR_TRWS "/home/gasst/Downloads/TRW_S-v1.3/" CACHE  FILEPATH "Directory for TRWS") 
+  set(DIR_TRWS "${CMAKE_CURRENT_SOURCE_DIR}/External/TRW_S-v1.3/" CACHE  FILEPATH "Directory for TRWS") 
   if (NOT EXISTS ${DIR_TRWS}/MRFEnergy.h)
     message(SEND_ERROR "TRW-S directory not found or does not appear to contain the TRW-S library")
     set(DIR_TRWS "TRW-S DIR NOTFOUND" CACHE  FILEPATH "Directory for TRWS" FORCE) 
@@ -54,6 +54,7 @@ if( ${USE_TRWS} MATCHES "ON" )
 
     #patch it!
     MESSAGE( STATUS "Patching TRWS")
+    #message("cmake -E chdir ${DIR_TRWS} patch -r - -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/External/Patches/TRWS.patch")
     EXECUTE_PROCESS( COMMAND cmake -E chdir ${DIR_TRWS} patch -r - -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/External/Patches/TRWS.patch  RESULT_VARIABLE RESULT_PATCH OUTPUT_QUIET)
     MESSAGE( STATUS "Patch result: ${RESULT_PATCH}, PROF SOURCE DIR: ${DIR_TRWS}" )
     if (  ${RESULT_PATCH} MATCHES "2")
@@ -75,7 +76,7 @@ endif()
 
 if( ${USE_GCO} MATCHES "ON" )
   add_definitions(-DWITH_GCO -DGCO_ENERGYTYPE=double -DGCO_ENERGYTERMTYPE=float)
-  set(DIR_GCO "${SRS-MRF_SOURCE_DIR}/External/GCO" CACHE  FILEPATH "Directory for GCO")
+  set(DIR_GCO "${CMAKE_CURRENT_SOURCE_DIR}/External/GCO" CACHE  FILEPATH "Directory for GCO")
   if (NOT EXISTS ${DIR_GCO}/GCoptimization.h)
     message(SEND_ERROR "GCO directory not found or does not appear to contain the GCO library")
     set(DIR_GCO "maxflow DIR NOTFOUND" CACHE  FILEPATH "Directory for GCO" FORCE) 
@@ -83,6 +84,7 @@ if( ${USE_GCO} MATCHES "ON" )
     
       #patch it!
     MESSAGE( STATUS "Patching GCO")
+    #message( "cmake -E chdir ${DIR_GCO} patch -r - -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/External/Patches/GCO.patch  RESULT_VARIABLE RESULT_PATCH OUTPUT_QUIET" )
     EXECUTE_PROCESS( COMMAND cmake -E chdir ${DIR_GCO} patch -r - -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/External/Patches/GCO.patch  RESULT_VARIABLE RESULT_PATCH OUTPUT_QUIET)
     MESSAGE( STATUS "Patch result: ${RESULT_PATCH}, PROF SOURCE DIR: ${DIR_GCO}" )
     if (  ${RESULT_PATCH} MATCHES "2")
@@ -102,7 +104,7 @@ endif()
 
 
 if( ${USE_GC} MATCHES "ON" )
-  set(DIR_GC "${SRS-MRF_SOURCE_DIR}/External/maxFlow" CACHE  FILEPATH "Directory for GC") 
+  set(DIR_GC "${CMAKE_CURRENT_SOURCE_DIR}/External/maxFlow" CACHE  FILEPATH "Directory for GC") 
   if (NOT EXISTS ${DIR_GC}/maxflow.cpp)
     message(SEND_ERROR "maxflow directory not found or does not appear to contain the maxflow library")
     set(DIR_GC "maxflow DIR NOTFOUND" CACHE  FILEPATH "Directory for GC" FORCE) 

--- a/source/SimultaneousRegistrationSegmentation/Optimizers/MRF-opengm.h
+++ b/source/SimultaneousRegistrationSegmentation/Optimizers/MRF-opengm.h
@@ -70,10 +70,10 @@ protected:
     int nSegLabels;
     bool m_segment, m_register,m_coherence;
     double m_lastLowerBound;
-    vector<int> m_labelOrder;
+    std::vector<int> m_labelOrder;
     int m_zeroDisplacementLabel;
     bool m_deleteRegNeighb;
-    vector<size_t> m_solution;
+    std::vector<size_t> m_solution;
 
    
     int GLOBALnRegNodes,GLOBALnSegNodes,GLOBALnSegLabels,GLOBALnRegLabels;
@@ -100,7 +100,7 @@ public:
         //createGraph();
         //init();
         m_gm=NULL;
-        m_labelOrder=vector<int>(this->m_GraphModel->nRegLabels());
+        m_labelOrder=std::vector<int>(this->m_GraphModel->nRegLabels());
         //order registration labels such that they start with zero displacement
         m_zeroDisplacementLabel=this->m_GraphModel->getLabelMapper()->getZeroDisplacementIndex();
         m_labelOrder[0]=m_zeroDisplacementLabel;
@@ -120,7 +120,7 @@ public:
 	~OPENGM_SRSMRFSolver()
     { 
 
-        LOGV(1)<<"Deleting OPENGM_MRF Sovler " << endl;
+        LOGV(1)<<"Deleting OPENGM_MRF Sovler " << std::endl;
      
         delete m_gm;
         
@@ -314,7 +314,7 @@ public:
 
         clock_t opt_start=clock();
         double energy;//=m_optimizer->compute_energy();
-        //LOGV(2)<<VAR(energy)<<endl;
+        //LOGV(2)<<VAR(energy)<<std::endl;
         try{
             solver.infer();
             //m_optimizer->swap(maxIter);
@@ -343,7 +343,7 @@ public:
         if (m_register){
             for (int i=0;i<nRegNodes;++i){
                 Labels[i]=m_solution[i];
-                LOGV(20)<<"DEF "<<VAR(i)<<" "<<VAR(Labels[i])<<endl;
+                LOGV(20)<<"DEF "<<VAR(i)<<" "<<VAR(Labels[i])<<std::endl;
             }
         }
         return Labels;
@@ -353,7 +353,7 @@ public:
         if (m_segment){
             for (int i=0;i<nSegNodes;++i){
                 Labels[i]=m_solution[i+GLOBALnRegNodes]-GLOBALnRegLabels;
-                LOGV(20)<<"SEG "<<VAR(i)<<" "<<VAR(Labels[i])<<endl;
+                LOGV(20)<<"SEG "<<VAR(i)<<" "<<VAR(Labels[i])<<std::endl;
             }
         }
         return Labels;


### PR DESCRIPTION
Slightly improved the documentation regarding:

1) Dependencies on the actual compiler (you might be able to improve this, but you need some compiler that supports `OpenMP` and `gcc-4.9` is one of them)
2) Where to place the missing `External` repositories, which is not exactly clear from the `README` otherwise.

Also fixed a few compiler errors that came up under OS X 10.10 (`std::` namespace reference missing).
